### PR TITLE
Update build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ def patchKeepSpecs() {
     for (int i = 0; i < length; ++i) {
         Object entry = Array.get(table, i)
         if (entry != null) {
-            Map.Entry<String, String> mapEntry = (Map.Entry<String, String>) entry
+            java.util.Map.Entry<String, String> mapEntry = (java.util.Map.Entry<String, String>) entry
             if ("activity".equals(mapEntry.getKey())) {
                 activityIndex = i
                 break


### PR DESCRIPTION
Fixed error below, I use a full qualified reference instead of an import

> startup failed:
>   build file 'App/build.gradle': 503: unable to resolve class Map.Entry 
>    @ line 503, column 39.
>                  Map.Entry<String, String> mapEntry = (Map.Entry<String, String>) entry
>                                            ^

  build file 'App/build.gradle': 503: unable to resolve class Map.Entry 
   @ line 503, column 50.
     ry<String, String> mapEntry = (Map.Entry
                                   ^

  2 errors
